### PR TITLE
Added remoteUsername to logout url

### DIFF
--- a/src/UserNameSessionProvider.php
+++ b/src/UserNameSessionProvider.php
@@ -519,6 +519,7 @@ class UserNameSessionProvider extends CookieSessionProvider {
 							$url = $internal->getLinkURL();
 						}
 						$personalurls[ 'logout' ][ 'href' ] = $url;
+						$personalurls[ 'logout' ][ 'text' ] = $metadata[ 'remoteUserName' ];
 						return true;
 					}
 				);


### PR DESCRIPTION
In case of a dedicated logout url the logout link have now url and title (remote username), before no text for the link was provided, resulting in an empty string "<0>"